### PR TITLE
fix: add package github actions get branch name

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v8
+
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
For the preview cleanup CI, the github actions package was missing to capture the branch name.